### PR TITLE
Refactor README and enhance RustCrypto FFI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,220 +1,81 @@
-# RustCrypto FFI wrapper
+# rustcrypto — Cryptography for Nim
 
-RustCrypto: https://github.com/RustCrypto
+Nim bindings to RustCrypto through a small Rust FFI static library. High-level APIs cover common protocols; low-level modules expose one primitive per file under `rustcrypto/algorithm/`.
 
-RustCrypto を Nim から安全に呼び出すための FFI ラッパーです。`nim_rustcrypto/algorithm/*` は SHA-256、HMAC-SHA256、HKDF-SHA256、PBKDF2-HMAC-SHA256、scrypt、Argon2id、PHC 文字列の検証・正規化、AES-256-GCM、AES-256-GCM-SIV、BLAKE2b-512、BLAKE2s-256、secp256k1 公開鍵導出、ECDSA 署名・検証、SHA-256 / SHA3-256 / Keccak-256 を使う secp256k1 ECDSA 署名・検証、`nim_rustcrypto/algorithm/schnorr.nim` から使う secp256k1 Schnorr の低水準公開鍵導出・署名・検証、Ed25519 の公開鍵導出・署名・検証、PKCS#8/SPKI 変換と PEM 変換、P-256 / P-384 ECDSA、X.509 証明書の最小読み取り、RSA-PSS 署名、RSA PKCS#1 v1.5 署名、RSA-OAEP 暗号化、RSA PKCS#1 v1.5 暗号化の低水準 API を提供します。その上に `nim_rustcrypto/bitcoin`、`nim_rustcrypto/lightning`、`nim_rustcrypto/ethereum`、`nim_rustcrypto/jwt` の高水準 API を重ね、プロトコル別の前処理や署名形式変換をまとめて扱えるようにしています。Schnorr は ECDSA とは別形式で、公開鍵と署名は互換ではありません。
+- **Upstream**: [RustCrypto](https://github.com/RustCrypto)
+- **License**: Dual-licensed (MIT / Apache-2.0)
 
-## 開発優先順位
+## Features (summary)
 
-- [x] 1. `digest` trait
-  - 用途: ハッシュ関数を共通FFIで包むための基盤。
-  - 依存先: なし。
-- [x] 2. `sha2`
-  - 用途: Bitcoinのtxid/block hash、Lightningの各種ハッシュ、関連する周辺実装。
-  - 依存先: `digest`。
-- [x] 3. `k256` (secp256k1)
-  - 用途: Bitcoin、Ethereum、Lightningの公開鍵・秘密鍵・曲線演算。
-  - 依存先: 署名APIでは`signature`、プロトコル上は`sha2`やKeccak系ハッシュと組み合わせる。
-- [x] 4. `signature` trait
-  - 用途: ECDSA、Ed25519、RSA署名を同じFFI設計で扱うための基盤。
-  - 依存先: なし。
-- [x] 5. `ecdsa`
-  - 用途: Bitcoin/Ethereum/Lightningのsecp256k1署名の土台。
-  - 依存先: `signature`, `k256`, `sha2`またはKeccak系ハッシュ。
-- [x] 6. `sha3`
-  - 用途: Ethereum互換のKeccak/SHA-3系ハッシュ、アドレス・署名対象データの処理。
-  - 依存先: `digest`。
-- [x] 7. `keccak`
-  - 用途: EthereumのKeccak-256互換性を低水準で明確に扱う場合。
-  - 依存先: `digest`相当のFFI設計。`sha3`で足りる範囲との切り分けが必要。
-- [x] 8. `hmac`
-  - 用途: メッセージ認証、鍵導出、プロトコル内検証。
-  - 依存先: `digest`、主に`sha2`。
-- [x] 9. `hkdf`
-  - 用途: Lightning/BOLT系や暗号化プロトコルでの鍵素材展開。
-  - 依存先: `hmac`, `digest`, 主に`sha2`。
-- [x] 10. `aead` trait
-  - 用途: 認証付き暗号を共通FFIで包むための基盤。
-  - 依存先: なし。
-- [x] 11. `cipher` trait
-  - 用途: 対称暗号の低水準共通API設計。
-  - 依存先: なし。
-- [x] 12. `chacha20poly1305`
-  - 用途: Lightning/BOLT系の通信暗号化、ソフトウェア実装向けAEAD。
-  - 依存先: `aead`, `cipher`。実プロトコルでは`hkdf`で導出した鍵を使う。
-- [x] 13. `der`
-  - 用途: ECDSA署名、公開鍵、証明書系データのDER入出力。
-  - 依存先: `ecdsa`, `rsa`, `p256`, `p384`, `const-oid`。
-- [x] 14. `pkcs8`
-  - 用途: 秘密鍵・公開鍵の標準形式での保存と読み込み。
-  - 依存先: `der`, `const-oid`, `k256`, `p256`, `p384`, `rsa`, `ed25519`。
-- [x] 15. `pem-rfc7468`
-  - 用途: PEM形式の鍵・証明書をCLIや外部ツールと交換する。
-  - 依存先: `der`, `pkcs8`, `x509-cert`。
-- [x] 16. `const-oid`
-  - 用途: DER/PKCS#8/X.509内のアルゴリズム識別子。
-  - 依存先: なし。`der`, `pkcs8`, `x509-cert`から利用される。
-- [x] 17. `ed25519`
-  - 用途: Nostrなど暗号資産周辺エコシステム、軽量な署名用途。
-  - 依存先: `signature`。必要に応じて`pkcs8`と`pem-rfc7468`。
-- [x] 18. `pbkdf2`
-  - 用途: 互換性重視のパスワード由来鍵生成、ウォレットファイル保護。
-  - 依存先: `hmac`, `digest`, `password-hash`。
-- [x] 19. `password-hash` trait
-  - 用途: `pbkdf2`、`scrypt`、`argon2`の出力形式と検証APIの共通化。
-  - 依存先: なし。
-- [x] 20. `scrypt`
-  - 用途: ウォレット・ローカル秘密鍵のパスワード保護。
-  - 依存先: `password-hash`。
-  - 実装メモ: N は 2 の冪として受け取り、Rust 側で `log_n` に変換する。
-- [x] 21. `argon2`
-  - 用途: 新規アプリでの強いパスワードハッシュ。
-  - 依存先: `password-hash`。
-  - 実装メモ: Argon2id のみを公開し、`m_cost`、`t_cost`、`p_cost`、`salt`、`hashLen` を明示する。
-- [x] 22. `aes-gcm`
-  - 用途: 一般的なAEAD暗号化、他システムとの互換用途。
-  - 依存先: `aead`, `cipher`。必要に応じて`hkdf`や`pbkdf2`。
-- [x] 23. `aes-gcm-siv`
-  - 用途: nonce再利用リスクに強いAEAD暗号化。
-  - 依存先: `aead`, `cipher`。
-- [x] 24. `blake2`
-  - 用途: 高速ハッシュ、暗号資産周辺プロトコルやアプリ内部ID。
-  - 依存先: `digest`。
-- [x] 25. `p256`
-  - 用途: WebAuthn、証明書、一般Web/PKI連携。
-  - 依存先: `signature`、`ecdsa`、`der`、`pkcs8`。
-- [x] 26. `p384`
-  - 用途: 高セキュリティ寄りのPKI/証明書連携。
-  - 依存先: `signature`、`ecdsa`、`der`、`pkcs8`。
-- [x] 27. `x509-cert`
-  - 用途: 証明書の読み書き、TLS/PKI系ツールとの連携。
-  - 依存先: `der`, `const-oid`, `p256`, `p384`, `rsa`。
-- [x] 28. `rsa` signatures
-  - 用途: 既存PKIや古いシステムとの署名互換。
-  - 依存先: `signature`, `digest`, `rsa`, `der`, `pkcs8`。
-- [x] 29. `rsa` asymmetric encryption
-  - 用途: 互換用途の公開鍵暗号化。Bitcoin/Ethereum/Lightningの中核ではない。
-  - 依存先: `rsa`, `der`, `pkcs8`, `pem-rfc7468`。
-- [ ] 30. `dsa`
-  - 用途: レガシー署名互換。
-  - 依存先: `signature`, `digest`, `der`。
-- [ ] 31. `elliptic-curves` asymmetric encryption
-  - 用途: ECDH/ECIES風の鍵共有・暗号化設計が必要になった場合。
-  - 依存先: 対象曲線、`hkdf`, `aead`。
-- [ ] 32. `ascon`
-  - 用途: 軽量暗号・軽量スポンジ関数の実験的または組み込み向け用途。
-  - 依存先: `digest`相当のFFI設計。AEADとして扱う場合は`aead`。
-- [ ] 33. `ml-kem`
-  - 用途: 将来の耐量子KEM対応。現時点のBitcoin/Ethereum/Lightning中核では後回し。
-  - 依存先: KEM用のFFI設計。必要に応じて`hkdf`や`aead`と組み合わせる。
+Hashing (SHA-256, SHA3-256, Keccak-256, BLAKE2), HMAC, HKDF, PBKDF2, scrypt, Argon2id, AEAD (ChaCha20-Poly1305, AES-256-GCM, AES-256-GCM-SIV), secp256k1 (ECDSA, Schnorr, recoverable ECDSA), Ed25519, NIST P-256 / P-384 ECDSA, RSA (sign/verify, OAEP, PKCS#1 v1.5), X.509 minimal parsing, PKCS#8 / SPKI / PEM for supported keys, plus **Bitcoin**, **Lightning (BOLT-11 signing)**, **Ethereum**, and **JWT** helpers.
 
-## 使い方
+## Installation
 
-### Rust
-
-Rust 側は `src/rustcrypto-ffi` でビルドします。
-
-```bash
-cd src/rustcrypto-ffi
-cargo test
-cargo build --release --lib
+```sh
+nimble add "https://github.com/itsumura-h/nim-rustcrypto?subdir=src/nim-rustcrypto"
 ```
 
-### Nim
+Or in your `.nimble` file:
 
-Nim 側は `src/nim-rustcrypto` でビルドします。`nim_rustcrypto` を import すると、低水準 FFI と高水準 API の両方を使えます。
-
-```bash
-cd src/nim-rustcrypto
-nimble test -y
+```nim
+requires "https://github.com/itsumura-h/nim-rustcrypto?subdir=src/nim-rustcrypto"
 ```
 
-## 提供 API
+## Documentation
 
-- `sha256`, `sha256Hex`
-- `hmacSha256`, `hmacSha256Hex`
-- `pbkdf2HmacSha256`
-- `scrypt`
-- `argon2idDerive`, `argon2idHashPassword`, `argon2idVerifyPassword`
-- `passwordHashValidate`, `passwordHashCanonicalize`
-- `hkdfSha256Extract`, `hkdfSha256Expand`, `hkdfSha256Derive`
-- `chacha20poly1305Encrypt`, `chacha20poly1305Decrypt`
-- `aes256gcmEncrypt`, `aes256gcmDecrypt`
-- `aes256gcmsivEncrypt`, `aes256gcmsivDecrypt`
-- `secp256k1PublicKeyCompressed`, `secp256k1PublicKeyUncompressed`
-- `secp256k1EcdsaSign`, `secp256k1EcdsaVerify`
-- `secp256k1EcdsaSignSha256`, `secp256k1EcdsaVerifySha256`
-- `secp256k1EcdsaSignSha3_256`, `secp256k1EcdsaVerifySha3_256`
-- `secp256k1EcdsaSignKeccak256`, `secp256k1EcdsaVerifyKeccak256`
-- `secp256k1EcdsaSignatureToDer`, `secp256k1EcdsaSignatureFromDer`
-- `schnorrPublicKey`, `schnorrSign`, `schnorrVerify` (`nim_rustcrypto/algorithm/schnorr.nim` の低水準 API)
-- `ed25519PublicKeyFromSecretKey`, `ed25519Sign`, `ed25519Verify`
-- `ed25519PrivateKeyToPkcs8Der`, `ed25519PrivateKeyFromPkcs8Der`
-- `ed25519PublicKeyToSpkiDer`, `ed25519PublicKeyFromSpkiDer`
-- `ed25519PrivateKeyToPkcs8Pem`, `ed25519PrivateKeyFromPkcs8Pem`
-- `ed25519PublicKeyToSpkiPem`, `ed25519PublicKeyFromSpkiPem`
-- `sha3_256`, `sha3_256Hex`
-- `keccak256`, `keccak256Hex`
-- `blake2b512`, `blake2b512Hex`
-- `blake2s256`, `blake2s256Hex`
-- `p256PublicKeyCompressed`, `p256PublicKeyUncompressed`
-- `p256EcdsaSignSha256`, `p256EcdsaVerifySha256`
-- `p256EcdsaSignPrehash`, `p256EcdsaVerifyPrehash`
-- `p256PrivateKeyToPkcs8Der`, `p256PrivateKeyFromPkcs8Der`
-- `p256PublicKeyToSpkiDer`, `p256PublicKeyFromSpkiDer`
-- `p384PublicKeyCompressed`, `p384PublicKeyUncompressed`
-- `p384EcdsaSignSha384`, `p384EcdsaVerifySha384`
-- `p384EcdsaSignPrehash`, `p384EcdsaVerifyPrehash`
-- `p384PrivateKeyToPkcs8Der`, `p384PrivateKeyFromPkcs8Der`
-- `p384PublicKeyToSpkiDer`, `p384PublicKeyFromSpkiDer`
-- `x509CertValidateDer`, `x509CertFromPem`, `x509CertToPem`
-- `x509CertSubjectPublicKeyInfoDer`, `x509CertSignatureAlgorithmOid`
-- `x509CertSubjectDer`, `x509CertIssuerDer`
-- `rsaPrivateKeyToPkcs8Der`, `rsaPrivateKeyFromPkcs8Der`
-- `rsaPublicKeyToSpkiDer`, `rsaPublicKeyFromSpkiDer`
-- `rsaPssSignSha256`, `rsaPssVerifySha256`
-- `rsaPkcs1v15SignSha256`, `rsaPkcs1v15VerifySha256`
-- `rsaOaepSha256Encrypt`, `rsaOaepSha256Decrypt`
-- `rsaPkcs1v15Encrypt`, `rsaPkcs1v15Decrypt`
+Per-primitive and per-protocol guides (English):
 
-## 高水準 API
+### Hashing and MAC
 
-- `bitcoin`: Bitcoin Signed Message、BIP340 tagged hash、Taproot 向け署名補助
-- `lightning`: BOLT 11 invoice の hash と recoverable ECDSA 署名補助
-- `ethereum`: Keccak-256、アドレス導出、EIP-191/EIP-712 の署名補助
-- `jwt`: JWS Compact Serialization の `HS256`、`ES256`、`EdDSA`、`RS256`、`PS256`
+- [SHA-256](docs/sha256.md)
+- [SHA3-256 and Keccak-256](docs/sha3-keccak.md)
+- [BLAKE2b-512 / BLAKE2s-256](docs/blake2.md)
+- [HMAC-SHA256](docs/hmac.md)
 
-注意:
+### Key derivation and passwords
 
-- `jwt` は `alg: none` を受け付けません
-- `bitcoin` / `lightning` / `ethereum` はフルノード、ウォレット、トランザクション完全実装ではありません
-- `jwt` は JSON の正規化、claim 検証、JWKS 取得を行いません
+- [HKDF-SHA256](docs/hkdf.md)
+- [PBKDF2-HMAC-SHA256](docs/pbkdf2.md)
+- [scrypt](docs/scrypt.md)
+- [Argon2id](docs/argon2.md)
+- [PHC string validate / canonicalize](docs/password-hash-phc.md)
 
-## テストベクトル
+### AEAD
 
-- `SHA256("abc")`
-- `HMAC-SHA256` RFC 4231 test case 1/2
-- `PBKDF2-HMAC-SHA256` 既知ベクトル
-- `scrypt` RFC 7914 test vector 1/2/3
-- `Argon2id` 既知ベクトルと PHC 文字列の round-trip
-- `PHC` 文字列の既知ベクトルと round-trip
-- `HKDF-SHA256` RFC 5869 test case 1/3
-- `ChaCha20-Poly1305` RFC 8439 AEAD test vector
-- `AES-256-GCM` NIST SP 800-38D test vector と改ざん tag
-- `AES-256-GCM-SIV` RFC 8452 test vector と改ざん tag
-- `BLAKE2b-512` RFC 7693 test vector
-- `BLAKE2s-256` RFC 7693 test vector
-- secp256k1 秘密鍵 `0x...01` からの公開鍵導出
-- secp256k1 `abc` ダイジェストでの ECDSA 署名・検証
-- secp256k1 ECDSA SHA-256 / SHA3-256 / Keccak-256 の本文入力 API
-- secp256k1 ECDSA raw 64 バイト署名と DER 署名の相互変換
-- secp256k1 Schnorr の公開鍵導出、署名・検証、改ざん署名の失敗
-- Ed25519 RFC 8032 の公開鍵導出、署名・検証、改ざん署名の失敗
-- Ed25519 PKCS#8 / SPKI / PEM RFC 8410 / RFC 7468 の既知ベクトル
-- `SHA3-256("abc")`
-- `Keccak-256("abc")`
-- P-256 RFC 6979 test vector
-- P-384 RFC 6979 test vector
-- X.509 DER/PEM fixture の round-trip と SPKI 抽出
-- RSA-PSS / RSA PKCS#1 v1.5 の署名・検証
-- RSA-OAEP / RSA PKCS#1 v1.5 の暗号化・復号
+- [ChaCha20-Poly1305](docs/chacha20-poly1305.md)
+- [AES-256-GCM](docs/aes-256-gcm.md)
+- [AES-256-GCM-SIV](docs/aes-256-gcm-siv.md)
+
+### Elliptic-curve signatures and encodings
+
+- [secp256k1 ECDSA](docs/secp256k1-ecdsa.md)
+- [secp256k1 ECDSA (DER)](docs/secp256k1-ecdsa-der.md)
+- [secp256k1 Schnorr (BIP340-style)](docs/secp256k1-schnorr.md)
+- [Ed25519](docs/ed25519.md)
+- [P-256 ECDSA](docs/p256-ecdsa.md)
+- [P-384 ECDSA](docs/p384-ecdsa.md)
+
+### RSA and certificates
+
+- [RSA signatures and encryption](docs/rsa-signatures-and-encryption.md)
+- [X.509 (minimal)](docs/x509-certificates.md)
+- [PKCS#8, SPKI, PEM (keys)](docs/key-encoding-pkcs8-pem.md)
+
+### High-level protocol helpers
+
+- [Bitcoin](docs/bitcoin.md)
+- [Lightning (invoice signing)](docs/lightning.md)
+- [Ethereum](docs/ethereum.md)
+- [JWT (JWS compact)](docs/jwt-json-web-tokens.md)
+
+### FFI
+
+- [Low-level `algorithm/ffi`](docs/ffi-low-level.md)
+
+## Development
+
+Build and test Rust from `src/rustcrypto-ffi`, Nim from `src/nim-rustcrypto` (see project rules for exact commands). On GitHub, CI exercises the Nim test suite with the prebuilt static archive workflow.
+
+## License
+
+Use under **MIT** or **Apache-2.0**, at your option.

--- a/docs/aes-256-gcm-siv.md
+++ b/docs/aes-256-gcm-siv.md
@@ -1,0 +1,29 @@
+# AES-256-GCM-SIV
+
+Module: `rustcrypto/algorithm/aesgcmsiv`
+
+AES-256-GCM-SIV (RFC 8452): misuse-resistant AEAD with deterministic encryption for a given `(key, nonce)` pair. API shape matches AES-GCM: typed key/nonce/tag arrays and `seq[byte]` payloads.
+
+## Types
+
+- `Aes256GcmSivKey` — 32 bytes
+- `Aes256GcmSivNonce` — 12 bytes
+- `Aes256GcmSivTag` — 16 bytes
+
+Use `fromHexKey`, `fromHexNonce`, `fromHexTag`, or `fromHex` on each type.
+
+## Encrypt / decrypt
+
+```nim
+import rustcrypto/algorithm/aesgcmsiv
+
+let key = fromHexKey("...")
+let nonce = fromHexNonce("...")
+let plaintext: seq[byte] = @[...]
+let aad: seq[byte] = @[]
+
+let (ciphertext, tag) = aes256gcmsivEncrypt(key, nonce, plaintext, aad)
+let recovered = aes256gcmsivDecrypt(key, nonce, ciphertext, tag, aad)
+```
+
+Tampering with ciphertext, tag, or AAD causes decryption to fail with `ValueError`.

--- a/docs/aes-256-gcm.md
+++ b/docs/aes-256-gcm.md
@@ -1,0 +1,34 @@
+# AES-256-GCM
+
+Module: `rustcrypto/algorithm/aesgcm`
+
+Authenticated encryption with AES-256-GCM. Keys, nonces, and tags are fixed-size byte arrays; plaintext and ciphertext are `seq[byte]` (and accept `openArray[byte]` for inputs).
+
+## Types
+
+- `Aes256GcmKey` — 32 bytes
+- `Aes256GcmNonce` — 12 bytes
+- `Aes256GcmTag` — 16 bytes
+
+Helpers: `fromHexKey`, `fromHexNonce`, `fromHexTag`, or `Aes256GcmKey.fromHex(...)`, etc.
+
+## Encrypt
+
+```nim
+import rustcrypto/algorithm/aesgcm
+
+let key = fromHexKey("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+let nonce = fromHexNonce("000000000000000000000001")
+let plaintext = @[byte('h'), byte('i')]
+let aad = newSeq[byte]()
+
+let (ciphertext, tag) = aes256gcmEncrypt(key, nonce, plaintext, aad)
+```
+
+## Decrypt
+
+```nim
+let recovered = aes256gcmDecrypt(key, nonce, ciphertext, tag, aad)
+```
+
+Authentication failure raises `ValueError` (`authentication failed`).

--- a/docs/argon2.md
+++ b/docs/argon2.md
@@ -1,0 +1,51 @@
+# Argon2id
+
+Module: `rustcrypto/algorithm/argon2`
+
+Argon2id via Rust FFI: raw key derivation and PHC-string password hashing.
+
+## Types
+
+- `Argon2idOkm` — `seq[byte]` raw output
+- `Argon2idPasswordHashString` — PHC-encoded string (for storage)
+
+## Raw derive
+
+```nim
+import rustcrypto/algorithm/argon2
+import rustcrypto/algorithm/common
+
+let key = argon2idDerive(
+  password = "password",
+  salt = "somesaltbytes",
+  mCost = 19456,   # KiB — example only
+  tCost = 2,
+  pCost = 1,
+  hashLen = 32,
+)
+```
+
+`mCost`, `tCost`, and `pCost` must be positive. `hashLen` must meet the library minimum (`Argon2idMinHashLen` in `rustcrypto/algorithm/ffi`).
+
+## PHC password hash (encode)
+
+You must supply an explicit salt string (the routine does not generate one for you):
+
+```nim
+let phc = argon2idHashPassword(
+  password = "user-password",
+  salt = "random-salt-bytes",
+  mCost = 19456,
+  tCost = 2,
+  pCost = 1,
+  hashLen = 32,
+)
+```
+
+## PHC password verify
+
+```nim
+let ok = argon2idVerifyPassword("user-password", phc)
+```
+
+Returns `false` on password mismatch; invalid PHC format raises `ValueError`.

--- a/docs/bitcoin.md
+++ b/docs/bitcoin.md
@@ -1,0 +1,54 @@
+# Bitcoin helpers
+
+Module: `rustcrypto/bitcoin`
+
+Convenience types and procedures for Bitcoin-style message hashing, compact recoverable signatures, ECDSA over a provided digest, and Taproot-related Schnorr over a digest.
+
+## Types
+
+- `BitcoinMessageHash` — `Sha256Digest` (32 bytes)
+- `BitcoinMessageSignature` — 65-byte compact recoverable form (header byte + 64-byte sig)
+- `BitcoinEcdsaSignature` — raw 64-byte ECDSA (`Secp256k1Signature`)
+- `BitcoinSchnorrSignature`, `BitcoinXOnlyPublicKey` — Schnorr types from `algorithm/schnorr`
+- `BitcoinNetwork` — enum (`bitcoinMainnet`, `bitcoinTestnet`, `bitcoinRegtest`) (reserved for future network-specific formatting)
+
+## Double SHA-256 (`hash256`)
+
+```nim
+import rustcrypto/bitcoin
+
+let h = bitcoinHash256(someBytes)
+```
+
+## BIP-340 tagged hash
+
+```nim
+let h = bitcoinTaggedHash("TagName", messageBytes)
+```
+
+## Bitcoin Signed Message (legacy)
+
+```nim
+import rustcrypto/bitcoin
+import rustcrypto/algorithm/secp256k1
+
+let sig = bitcoinSignMessage("Hello", secretKey)
+discard bitcoinVerifyMessage("Hello", compressedPubKey, sig)
+```
+
+## ECDSA on an arbitrary 32-byte digest
+
+```nim
+let digest: BitcoinMessageHash = bitcoinMessageHash("Hello")
+let sig = bitcoinSignDigestEcdsa(digest, secretKey)
+discard bitcoinVerifyDigestEcdsa(digest, compressedPubKey, sig)
+```
+
+## Schnorr on a 32-byte digest (Taproot signing workflows)
+
+```nim
+let sig = bitcoinSignTaprootDigest(digest, schnorrSecretKey)
+discard bitcoinVerifyTaprootDigest(digest, xOnlyPubKey, sig)
+```
+
+This crate does **not** implement full wallets, transaction parsing, or script execution.

--- a/docs/blake2.md
+++ b/docs/blake2.md
@@ -1,0 +1,28 @@
+# BLAKE2b-512 and BLAKE2s-256
+
+Module: `rustcrypto/algorithm/blake2`
+
+One-shot hashing of a Nim `string` into fixed-size digests, with optional hex encoding helpers.
+
+## Imports
+
+```nim
+import rustcrypto/algorithm/blake2
+import rustcrypto/algorithm/common
+```
+
+## BLAKE2b-512
+
+```nim
+let d = blake2b512("message")
+let hex = blake2b512Hex("message")
+let d2 = Blake2b512Digest.fromHexBlake2b512(hex)
+```
+
+## BLAKE2s-256
+
+```nim
+let d = blake2s256("message")
+let hex = blake2s256Hex("message")
+let d2 = Blake2s256Digest.fromHexBlake2s256(hex)
+```

--- a/docs/chacha20-poly1305.md
+++ b/docs/chacha20-poly1305.md
@@ -1,0 +1,29 @@
+# ChaCha20-Poly1305
+
+Module: `rustcrypto/algorithm/chacha20poly1305`
+
+AEAD ChaCha20-Poly1305 (RFC 8439 style): 32-byte key, 12-byte nonce, 16-byte tag.
+
+## Types
+
+- `ChaCha20Poly1305Key`
+- `ChaCha20Poly1305Nonce`
+- `ChaCha20Poly1305Tag`
+
+Hex helpers mirror AES-GCM (`fromHexKey`, etc.).
+
+## Encrypt / decrypt
+
+```nim
+import rustcrypto/algorithm/chacha20poly1305
+
+let key = fromHexKey("...")
+let nonce = fromHexNonce("...")
+let plaintext: seq[byte] = @[...]
+let aad: seq[byte] = @[]
+
+let (ciphertext, tag) = chacha20poly1305Encrypt(key, nonce, plaintext, aad)
+let recovered = chacha20poly1305Decrypt(key, nonce, ciphertext, tag, aad)
+```
+
+Invalid lengths or authentication failure surface as `ValueError`.

--- a/docs/ed25519.md
+++ b/docs/ed25519.md
@@ -1,0 +1,33 @@
+# Ed25519
+
+Module: `rustcrypto/algorithm/ed25519`
+
+Ed25519 signatures (RFC 8032 style) with `string` messages.
+
+## Types
+
+- `Ed25519SecretKey` — PKCS#8-compatible 32-byte seed material as used by the FFI layer
+- `Ed25519PublicKey`
+- `Ed25519Signature` — 64 bytes
+
+## Key generation and import
+
+```nim
+import rustcrypto/algorithm/ed25519
+
+let sk = randomSecretKey()
+# or
+let sk2 = fromHexSecretKey("aabb...") # 64 hex chars = 32 bytes
+let pk = ed25519PublicKeyFromSecretKey(sk)
+```
+
+## Sign / verify
+
+```nim
+let sig = ed25519Sign("hello", sk)
+discard ed25519Verify("hello", pk, sig)
+```
+
+## PKCS#8 / SPKI / PEM
+
+Encoding helpers live in `rustcrypto/algorithm/pkcs8` and `rustcrypto/algorithm/pem`. See [key-encoding-pkcs8-pem.md](./key-encoding-pkcs8-pem.md).

--- a/docs/ethereum.md
+++ b/docs/ethereum.md
@@ -1,0 +1,49 @@
+# Ethereum helpers
+
+Module: `rustcrypto/ethereum`
+
+Keccak-256, address derivation from an uncompressed secp256k1 key, EIP-191 personal message hashing, EIP-712 digest hashing, and **recoverable ECDSA** signatures with Ethereum `v` encoding.
+
+## Types
+
+- `EthereumAddress` — 20 bytes
+- `EthereumHash` — 32 bytes
+- `EthereumSignature` — `r`, `s` (32 bytes each), `v` (chain-aware)
+- `EthereumChainId` — `uint64` (`0` means legacy `v ∈ {27,28}`)
+
+## Keccak-256
+
+```nim
+import rustcrypto/ethereum
+
+let h = ethereumKeccak256(messageBytes)
+```
+
+## Address from uncompressed public key
+
+```nim
+let addr = ethereumAddress(uncompressedSecp256k1PubKey)
+```
+
+The public key must be a 65-byte SEC1 uncompressed point (`0x04 || X || Y`).
+
+## EIP-191 personal message
+
+```nim
+let digest = ethereumPersonalMessageHash("Hello")
+let sig = ethereumSignPersonalMessage("Hello", secretKey, chainId = 1)
+discard ethereumVerifyPersonalMessage("Hello", uncompressedPubKey, sig)
+```
+
+`ethereumVerifyPersonalMessage` tries recovery ids internally; unsupported `v` raises `ValueError`.
+
+## EIP-712 (precomputed hashes)
+
+When you already have `domainSeparator` and `structHash` as `EthereumHash`:
+
+```nim
+let sig = ethereumSignTypedDataHash(domainSeparator, structHash, secretKey, chainId = 1)
+discard ethereumVerifyTypedDataHash(domainSeparator, structHash, uncompressedPubKey, sig)
+```
+
+This module does **not** build EIP-712 structs from JSON or perform JSON canonicalization.

--- a/docs/ffi-low-level.md
+++ b/docs/ffi-low-level.md
@@ -1,0 +1,48 @@
+# Low-level FFI (`algorithm/ffi`)
+
+Module: `rustcrypto/algorithm/ffi`
+
+This module binds the static Rust archive and exposes `importc` C ABI functions (`*Raw` suffix in many call sites inside the library). High-level Nim wrappers in `rustcrypto/algorithm/*` are preferred: they pack buffers, translate status codes into `ValueError`, and use fixed-size types.
+
+## Platform
+
+The Nim package currently resolves the static library for **Linux x86_64** only; other targets fail at compile time with an error from `ffi.nim`.
+
+## Typical pattern
+
+1. Allocate output buffers with correct lengths (see `*Len` constants in the same module).
+2. Pass pointers via `bytesPtr` from `rustcrypto/algorithm/common` for `string` and `openArray[byte]`.
+3. Check the returned `cint` status against `RustCryptoOk`.
+
+```nim
+import rustcrypto/algorithm/ffi
+import rustcrypto/algorithm/common
+
+var outDigest: array[SHA256DigestLen, byte]
+let st = sha256Raw(
+  bytesPtr("abc"),
+  csize_t(3),
+  cast[ptr uint8](addr outDigest[0]),
+  csize_t(outDigest.len),
+)
+if st != RustCryptoOk:
+  raise newException(ValueError, "sha256Raw failed: " & $st)
+```
+
+`common.raiseRustCryptoStatus` is a small helper that throws on non-zero status.
+
+## Status codes (subset)
+
+The following are used across primitives (see `ffi.nim` for the full list):
+
+| Constant | Meaning |
+|----------|---------|
+| `RustCryptoOk` | Success |
+| `RustCryptoErrNullOutput` | Required output pointer was nil |
+| `RustCryptoErrOutputTooShort` | Output buffer too small |
+| `RustCryptoErrNullInputWithData` | Nil pointer with non-zero length |
+| `RustCryptoErrAuthenticationFailed` | AEAD tag verification failed |
+| `RustCryptoErrVerificationFailed` | Signature or password verify failed |
+| `RustCryptoErrPanic` | Rust side caught a panic at the FFI boundary |
+
+Prefer the typed wrappers (`sha256`, `aes256gcmEncrypt`, …) unless you are extending the library.

--- a/docs/hkdf.md
+++ b/docs/hkdf.md
@@ -1,0 +1,32 @@
+# HKDF-SHA256
+
+Module: `rustcrypto/algorithm/hkdf`
+
+HKDF (RFC 5869) using HMAC-SHA256. Salt, IKM, and `info` are Nim `string` values. Output lengths are in bytes (`int`).
+
+## Types
+
+- `HkdfSha256Prk` — 32-byte pseudorandom key (PRK) from extract
+- `HkdfSha256Okm` — `seq[byte]` output keying material from expand or one-shot derive
+
+## Extract
+
+```nim
+import rustcrypto/algorithm/hkdf
+
+let prk = hkdfSha256Extract("salt", "input-keying-material")
+```
+
+## Expand
+
+```nim
+let okm = hkdfSha256Expand(prk, "context-info", 32)
+```
+
+## One-shot (Extract + Expand)
+
+```nim
+let okm = hkdfSha256Derive("salt", "ikm", "info", 32)
+```
+
+Invalid lengths (negative or above the library maximum) raise `ValueError` before calling the FFI.

--- a/docs/hmac.md
+++ b/docs/hmac.md
@@ -1,0 +1,23 @@
+# HMAC-SHA256
+
+Module: `rustcrypto/algorithm/hmac`
+
+HMAC-SHA256 where both key and message are Nim `string` values. The MAC is a fixed 32-byte array (`HmacSha256Mac`).
+
+## Imports
+
+```nim
+import rustcrypto/algorithm/hmac
+import rustcrypto/algorithm/common
+```
+
+## Compute MAC
+
+```nim
+let mac = hmacSha256("key-bytes-as-string", "message")
+let hex = digestToHex(HmacSha256Mac, mac)
+# or
+let hex2 = hmacSha256Hex("key-bytes-as-string", "message")
+```
+
+Errors from the Rust FFI are raised as `ValueError` with an operation-specific message.

--- a/docs/jwt-json-web-tokens.md
+++ b/docs/jwt-json-web-tokens.md
@@ -1,0 +1,71 @@
+# JWT (JWS compact, selected algorithms)
+
+Module: `rustcrypto/jwt`
+
+Sign and verify JSON Web Tokens in **JWS Compact Serialization** form for:
+
+- `HS256` — HMAC-SHA256
+- `ES256` — ECDSA P-256 SHA-256 over the signing input
+- `EdDSA` — Ed25519
+- `RS256` — RSA PKCS#1 v1.5 with SHA-256
+- `PS256` — RSA-PSS with SHA-256
+
+## Header requirements
+
+- Header JSON must be valid JSON with a string `"alg"` field matching the function you call.
+- **`alg: none` is rejected** with `ValueError`.
+
+## Build signing input
+
+```nim
+import rustcrypto/jwt
+
+let signingInput = jwtSigningInput(headerJson, claimsJson)
+```
+
+## HS256
+
+```nim
+let token = jwtSignHS256(headerJson, claimsJson, secretBytes)
+discard jwtVerifyHS256(token, secretBytes)
+```
+
+## ES256
+
+```nim
+import rustcrypto/algorithm/p256
+
+let token = jwtSignES256(headerJson, claimsJson, secretKey)
+discard jwtVerifyES256(token, compressedOrUncompressedPubKey)
+```
+
+## EdDSA
+
+```nim
+import rustcrypto/algorithm/ed25519
+
+let token = jwtSignEdDSA(headerJson, claimsJson, secretKey)
+discard jwtVerifyEdDSA(token, publicKey)
+```
+
+## RS256 / PS256
+
+Pass PKCS#8 private key DER (sign) and SPKI public key DER (verify):
+
+```nim
+let token = jwtSignRS256(headerJson, claimsJson, rsaPrivateKeyDer)
+discard jwtVerifyRS256(token, rsaPublicKeyDer)
+
+let tokenPs = jwtSignPS256(headerJson, claimsJson, rsaPrivateKeyDer)
+discard jwtVerifyPS256(tokenPs, rsaPublicKeyDer)
+```
+
+## Base64url helpers
+
+`jwtBase64UrlEncode`, `jwtBase64UrlDecode`, and `jwtSigningInput` are exported for advanced callers.
+
+## Out of scope
+
+- Claim validation (`exp`, `aud`, …)
+- JSON canonicalization beyond what you place in `headerJson` / `claimsJson`
+- JWKS fetch and key rotation

--- a/docs/key-encoding-pkcs8-pem.md
+++ b/docs/key-encoding-pkcs8-pem.md
@@ -1,0 +1,53 @@
+# PKCS#8, SPKI, and PEM (keys)
+
+Encoding helpers are split across modules by algorithm. All examples use DER (`seq[byte]` or fixed arrays) unless noted.
+
+## Ed25519
+
+Modules: `rustcrypto/algorithm/pkcs8`, `rustcrypto/algorithm/pem`, `rustcrypto/algorithm/ed25519`
+
+```nim
+import rustcrypto/algorithm/ed25519
+import rustcrypto/algorithm/pkcs8
+import rustcrypto/algorithm/pem
+
+let sk = randomSecretKey()
+let pk = ed25519PublicKeyFromSecretKey(sk)
+
+let skDer = ed25519PrivateKeyToPkcs8Der(sk)
+let sk2 = ed25519PrivateKeyFromPkcs8Der(skDer)
+
+let pkDer = ed25519PublicKeyToSpkiDer(pk)
+let pk2 = ed25519PublicKeyFromSpkiDer(pkDer)
+
+let skPem = ed25519PrivateKeyToPkcs8Pem(sk)
+let skFromPem = ed25519PrivateKeyFromPkcs8Pem(skPem)
+
+let pkPem = ed25519PublicKeyToSpkiPem(pk)
+let pkFromPem = ed25519PublicKeyFromSpkiPem(pkPem)
+```
+
+## P-256 and P-384
+
+Module: `rustcrypto/algorithm/p256` (and `p384` with `Sha384` names)
+
+```nim
+import rustcrypto/algorithm/p256
+import rustcrypto/algorithm/ffi
+
+let sk = randomSecretKey()
+let skDer = p256PrivateKeyToPkcs8Der(sk)
+let sk2 = p256PrivateKeyFromPkcs8Der(skDer)
+
+let pk = p256PublicKeyCompressed(sk)
+let pkDer = p256PublicKeyToSpkiDer(pk, P256PublicKeyFormatCompressed)
+let pkBytes = p256PublicKeyFromSpkiDer(pkDer, P256PublicKeyFormatCompressed)
+```
+
+Use the matching `P384*` symbols from `rustcrypto/algorithm/p384` for P-384.
+
+## RSA
+
+Module: `rustcrypto/algorithm/rsa`
+
+RSA PKCS#8 / SPKI normalization is described in [rsa-signatures-and-encryption.md](./rsa-signatures-and-encryption.md).

--- a/docs/lightning.md
+++ b/docs/lightning.md
@@ -1,0 +1,49 @@
+# Lightning (BOLT-11 invoice signing)
+
+Module: `rustcrypto/lightning`
+
+Helpers for payment preimage hashing, node id derivation, and **BOLT-11 invoice signing hashes** with recoverable ECDSA signatures.
+
+## Types
+
+- `LightningPaymentPreimage` — 32 bytes
+- `LightningPaymentHash` — `Sha256Digest`
+- `LightningNodeId` — `Secp256k1CompressedPublicKey`
+- `LightningInvoiceSignature` — `Secp256k1RecoverableSignature`
+
+## Payment hash
+
+```nim
+import rustcrypto/lightning
+
+let paymentHash = lightningPaymentHash(preimage32)
+```
+
+## Node id
+
+```nim
+let nodeId = lightningNodeId(secretKey)
+```
+
+## Invoice signing hash
+
+The caller splits a BOLT-11 string into the **human-readable part (`hrp`)** and the **5-bit decoded data without the signature block**, then passes the raw data bytes:
+
+```nim
+let h = lightningInvoiceSigningHash(hrpString, dataPartWithoutSignature)
+```
+
+## Sign / verify invoice material
+
+```nim
+let sig = lightningSignInvoice(hrpString, dataPartWithoutSignature, secretKey)
+discard lightningVerifyInvoice(hrpString, dataPartWithoutSignature, nodeId, sig)
+```
+
+If you already computed the signing hash:
+
+```nim
+discard lightningVerifyInvoiceHash(signingHash, nodeId, sig)
+```
+
+This is **not** a full BOLT-11 parser: you must supply `hrp` and the decoded payload bytes in the shape expected by BOLT-11.

--- a/docs/p256-ecdsa.md
+++ b/docs/p256-ecdsa.md
@@ -1,0 +1,48 @@
+# P-256 (secp256r1) ECDSA
+
+Module: `rustcrypto/algorithm/p256`
+
+NIST P-256 ECDSA with SHA-256 message hashing, or pre-hashed P-256 digests. Keys and signatures are strongly typed arrays; PKCS#8 / SPKI DER import/export is supported.
+
+## Keys and random material
+
+```nim
+import rustcrypto/algorithm/p256
+
+let sk = randomSecretKey()
+# or deterministic test keys:
+let sk2 = fromHexSecretKey("...")
+let pkComp = p256PublicKeyCompressed(sk)
+let pkUncomp = p256PublicKeyUncompressed(sk)
+```
+
+## Sign / verify (message → SHA-256 → ECDSA)
+
+```nim
+let sig = p256EcdsaSignSha256("message", sk)
+
+import rustcrypto/algorithm/ffi
+
+discard p256EcdsaVerifySha256("message", pkComp, P256PublicKeyFormatCompressed, sig)
+discard p256EcdsaVerifySha256("message", pkUncomp, P256PublicKeyFormatUncompressed, sig)
+```
+
+Public key format constants: `P256PublicKeyFormatCompressed`, `P256PublicKeyFormatUncompressed` in `rustcrypto/algorithm/ffi`.
+
+## Pre-hashed API
+
+When the message is already hashed to a P-256 digest:
+
+```nim
+let digest = fromHexMessageDigest("...")
+let sig = p256EcdsaSignPrehash(digest, sk)
+discard p256EcdsaVerifyPrehash(digest, pkComp, P256PublicKeyFormatCompressed, sig)
+```
+
+## PKCS#8 / SPKI
+
+See [key-encoding-pkcs8-pem.md](./key-encoding-pkcs8-pem.md) for `p256PrivateKeyToPkcs8Der` and related symbols.
+
+## JWT
+
+P-256 is used by `jwtSignES256` / `jwtVerifyES256`. See [jwt-json-web-tokens.md](./jwt-json-web-tokens.md).

--- a/docs/p384-ecdsa.md
+++ b/docs/p384-ecdsa.md
@@ -1,0 +1,31 @@
+# P-384 ECDSA
+
+Module: `rustcrypto/algorithm/p384`
+
+Same shape as P-256, but messages are hashed with SHA-384 for the message APIs, and prehash APIs use `P384MessageDigest`.
+
+## Sign / verify with SHA-384
+
+```nim
+import rustcrypto/algorithm/p384
+import rustcrypto/algorithm/ffi
+
+let sk = randomSecretKey()
+let pk = p384PublicKeyCompressed(sk)
+let sig = p384EcdsaSignSha384("message", sk)
+discard p384EcdsaVerifySha384("message", pk, P384PublicKeyFormatCompressed, sig)
+```
+
+Public key format constants: `P384PublicKeyFormatCompressed` / `P384PublicKeyFormatUncompressed` in `rustcrypto/algorithm/ffi`.
+
+## Pre-hashed API
+
+```nim
+let digest = fromHexMessageDigest("...")
+let sig = p384EcdsaSignPrehash(digest, sk)
+discard p384EcdsaVerifyPrehash(digest, pk, P384PublicKeyFormatCompressed, sig)
+```
+
+## PKCS#8 / SPKI
+
+See [key-encoding-pkcs8-pem.md](./key-encoding-pkcs8-pem.md).

--- a/docs/password-hash-phc.md
+++ b/docs/password-hash-phc.md
@@ -1,0 +1,26 @@
+# PHC password hash strings
+
+Module: `rustcrypto/algorithm/passwordhash`
+
+Helpers to validate and canonicalize PHC-encoded password hash strings (as produced by `argon2idHashPassword` and similar flows).
+
+## Validate
+
+```nim
+import rustcrypto/algorithm/passwordhash
+
+if passwordHashValidate(phcString):
+  echo "format looks valid"
+```
+
+Returns `true` only when the FFI reports success; invalid format returns `false` (see implementation for edge cases).
+
+## Canonicalize
+
+```nim
+let canonical: PasswordHashString = passwordHashCanonicalize(phcString)
+```
+
+Raises `ValueError` if the string cannot be canonicalized.
+
+See also [argon2.md](./argon2.md).

--- a/docs/pbkdf2.md
+++ b/docs/pbkdf2.md
@@ -1,0 +1,27 @@
+# PBKDF2-HMAC-SHA256
+
+Module: `rustcrypto/algorithm/pbkdf2`
+
+PBKDF2 with HMAC-SHA256. Password and salt are Nim `string` values. Iterations and output length are `int` (byte length of the derived key).
+
+## Usage
+
+```nim
+import rustcrypto/algorithm/pbkdf2
+import rustcrypto/algorithm/common
+
+let okm = pbkdf2HmacSha256(
+  password = "password",
+  salt = "saltsaltsaltsalt",
+  iterations = 100_000,
+  okmLen = 32,
+)
+let hex = digestToHex(byte, okm)
+```
+
+## Validation
+
+- `iterations` must be positive.
+- `okmLen` must be non-negative.
+
+Violations raise `ValueError`. FFI failures also raise `ValueError`.

--- a/docs/rsa-signatures-and-encryption.md
+++ b/docs/rsa-signatures-and-encryption.md
@@ -1,0 +1,51 @@
+# RSA (signatures and encryption)
+
+Module: `rustcrypto/algorithm/rsa`
+
+RSA operations use **DER-encoded keys** as `openArray[byte]` (typically PKCS#8 for private keys and SPKI for public keys). Returned signatures and ciphertexts are `seq[byte]`.
+
+## Key normalization helpers
+
+These routines parse and re-encode RSA keys into a canonical PKCS#8 / SPKI DER form (`RsaPrivateKeyDer`, `RsaPublicKeyDer` are `seq[byte]` type aliases):
+
+```nim
+import rustcrypto/algorithm/rsa
+
+let privNorm = rsaPrivateKeyToPkcs8Der(privateKeyDerFromFile)
+let privRoundTrip = rsaPrivateKeyFromPkcs8Der(privNorm)
+
+let pubNorm = rsaPublicKeyToSpkiDer(publicKeyDerFromFile)
+let pubRoundTrip = rsaPublicKeyFromSpkiDer(pubNorm)
+```
+
+## RSASSA-PSS with SHA-256
+
+```nim
+let sig = rsaPssSignSha256("message", privateKeyDer)
+discard rsaPssVerifySha256("message", publicKeyDer, sig)
+```
+
+## RSASSA-PKCS1-v1_5 with SHA-256
+
+```nim
+let sig = rsaPkcs1v15SignSha256("message", privateKeyDer)
+discard rsaPkcs1v15VerifySha256("message", publicKeyDer, sig)
+```
+
+## RSA-OAEP (SHA-256)
+
+Optional OAEP `label` string (often empty):
+
+```nim
+let ct = rsaOaepSha256Encrypt(plaintextBytes, publicKeyDer, label = "")
+let pt = rsaOaepSha256Decrypt(ct, privateKeyDer, label = "")
+```
+
+## RSA PKCS#1 v1.5 encryption
+
+```nim
+let ct = rsaPkcs1v15Encrypt(plaintextBytes, publicKeyDer)
+let pt = rsaPkcs1v15Decrypt(ct, privateKeyDer)
+```
+
+Decryption failures raise `ValueError`.

--- a/docs/scrypt.md
+++ b/docs/scrypt.md
@@ -1,0 +1,29 @@
+# scrypt
+
+Module: `rustcrypto/algorithm/scrypt`
+
+scrypt key derivation. Password and salt are Nim `string` values. The CPU/memory cost parameter `n` must be a power of two and at least 2. Parameters `r` and `p` must be positive. Output length is `okmLen` in bytes.
+
+## Usage
+
+```nim
+import rustcrypto/algorithm/scrypt
+import rustcrypto/algorithm/common
+
+# n = 32768 (2^15), r = 8, p = 1 — example parameters only; tune for your threat model
+let okm = scrypt(
+  password = "password",
+  salt = "saltsaltsaltsalt",
+  n = 32768,
+  r = 8,
+  p = 1,
+  okmLen = 32,
+)
+```
+
+## Notes
+
+- `n` must satisfy `(n and (n - 1)) == 0` (power of two).
+- The library validates `n`, `r`, `p`, and `okmLen`; invalid combinations raise `ValueError`.
+
+This API uses the raw scrypt `N` parameter (not `log2(N)`).

--- a/docs/secp256k1-ecdsa-der.md
+++ b/docs/secp256k1-ecdsa-der.md
@@ -1,0 +1,21 @@
+# secp256k1 ECDSA (DER)
+
+Module: `rustcrypto/algorithm/secp256k1_ecdsa_der`
+
+Convert between the library’s fixed 64-byte raw ECDSA signature (`Secp256k1Signature`) and ASN.1 DER encoding.
+
+## To DER
+
+```nim
+import rustcrypto/algorithm/secp256k1_ecdsa_der
+
+let der = secp256k1EcdsaSignatureToDer(raw64ByteSignature)
+```
+
+## From DER
+
+```nim
+let raw = secp256k1EcdsaSignatureFromDer(derBytes)
+```
+
+Invalid DER raises `ValueError`.

--- a/docs/secp256k1-ecdsa.md
+++ b/docs/secp256k1-ecdsa.md
@@ -1,0 +1,75 @@
+# secp256k1 ECDSA
+
+Modules:
+
+- `rustcrypto/algorithm/secp256k1` — keys, raw ECDSA over 32-byte digests, recoverable signatures
+- `rustcrypto/algorithm/sha256` — `secp256k1EcdsaSignSha256` / `VerifySha256` (message `string`, SHA-256 inside FFI)
+- `rustcrypto/algorithm/sha3` — SHA3-256 and Keccak-256 message helpers
+
+## Types
+
+- `Secp256k1SecretKey` — 32-byte array
+- `Secp256k1CompressedPublicKey` / `Secp256k1UncompressedPublicKey`
+- `Secp256k1MessageDigest` — 32-byte prehash for raw sign/verify
+- `Secp256k1Signature` — 64-byte compact ECDSA
+- `Secp256k1RecoverableSignature` — 65 bytes (last byte recovery id)
+
+## Random secret key
+
+```nim
+import rustcrypto/algorithm/secp256k1
+
+let sk = randomSecretKey()
+let pk = secp256k1PublicKeyCompressed(sk)
+```
+
+## Secret key from 64-char hex
+
+```nim
+import rustcrypto/algorithm/common
+import rustcrypto/algorithm/secp256k1
+import rustcrypto/algorithm/ffi
+
+const skHex = "0000000000000000000000000000000000000000000000000000000000000001"
+let sk = fromHexDigest[Secp256k1SecretKey](skHex, Secp256k1SecretKeyLen)
+```
+
+## Sign / verify a 32-byte digest (raw)
+
+Use a 32-byte digest (for example SHA-256 of your payload) as `Secp256k1MessageDigest`:
+
+```nim
+import rustcrypto/algorithm/common
+import rustcrypto/algorithm/secp256k1
+import rustcrypto/algorithm/ffi
+
+const digestHex =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" # SHA-256 of ""
+let digest = fromHexDigest[Secp256k1MessageDigest](digestHex, Secp256k1MessageDigestLen)
+let sig = secp256k1EcdsaSign(digest, sk)
+discard secp256k1EcdsaVerify(digest, pk, sig)
+```
+
+`secp256k1EcdsaVerify` is overloaded for compressed and uncompressed public keys.
+
+## Sign / verify a message string (SHA-256)
+
+```nim
+import rustcrypto/algorithm/sha256
+
+let sig = secp256k1EcdsaSignSha256("hello", sk)
+discard secp256k1EcdsaVerifySha256("hello", pk, sig)
+```
+
+## Recoverable signatures
+
+```nim
+let rsig = secp256k1EcdsaSignRecoverable(digest, sk)
+discard secp256k1EcdsaRecoverableVerify(digest, pk, rsig)
+```
+
+Used by Bitcoin message signing and Ethereum personal signing helpers.
+
+## DER encoding
+
+See [secp256k1-ecdsa-der.md](./secp256k1-ecdsa-der.md).

--- a/docs/secp256k1-schnorr.md
+++ b/docs/secp256k1-schnorr.md
@@ -1,0 +1,36 @@
+# secp256k1 Schnorr (BIP340-style)
+
+Module: `rustcrypto/algorithm/schnorr`
+
+Schnorr signatures on secp256k1 with x-only public keys. **Not compatible** with ECDSA public keys or signatures on the same curve.
+
+## Types
+
+- `SchnorrSecretKey` — 32 bytes (same length as ECDSA secret scalars; different key handling)
+- `SchnorrPublicKey` — x-only encoding
+- `SchnorrSignature` — fixed-length signature bytes
+
+## Random key
+
+```nim
+import rustcrypto/algorithm/schnorr
+
+let sk = randomSecretKey()
+let pk = schnorrPublicKey(sk)
+```
+
+## Sign / verify
+
+`message` overloads exist for `string` and `openArray[byte]`:
+
+```nim
+let sig = schnorrSign("hello", sk)
+discard schnorrVerify("hello", pk, sig)
+
+let sig2 = schnorrSign(messageBytes, sk)
+discard schnorrVerify(messageBytes, pk, sig2)
+```
+
+## Bitcoin Taproot digest helpers
+
+`rustcrypto/bitcoin` exposes `bitcoinSignTaprootDigest` / `bitcoinVerifyTaprootDigest`, which call these primitives on a precomputed 32-byte digest. See [bitcoin.md](./bitcoin.md).

--- a/docs/sha256.md
+++ b/docs/sha256.md
@@ -1,0 +1,33 @@
+# SHA-256
+
+Module: `rustcrypto/algorithm/sha256`
+
+SHA-256 over the full message as a single Nim `string`. The digest is a fixed 32-byte array (`Sha256Digest`).
+
+## Imports
+
+```nim
+import rustcrypto/algorithm/sha256
+import rustcrypto/algorithm/common
+```
+
+## One-shot hash
+
+```nim
+let digest = sha256("Hello, world!")
+let hex = digestToHex(Sha256Digest, digest)
+# or
+let hex2 = sha256Hex("Hello, world!")
+```
+
+## Parse a digest from hex
+
+```nim
+let digest = Sha256Digest.fromHex(
+  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+)
+```
+
+## ECDSA helpers on the same module
+
+`sha256.nim` also exports `secp256k1EcdsaSignSha256` / `secp256k1EcdsaVerifySha256`, which hash the message with SHA-256 before signing or verifying. See [secp256k1-ecdsa.md](./secp256k1-ecdsa.md).

--- a/docs/sha3-keccak.md
+++ b/docs/sha3-keccak.md
@@ -1,0 +1,37 @@
+# SHA3-256 and Keccak-256
+
+Module: `rustcrypto/algorithm/sha3`
+
+Provides SHA3-256 (NIST) and Keccak-256 (Ethereum-style, without the NIST padding tweak).
+
+## Imports
+
+```nim
+import rustcrypto/algorithm/sha3
+import rustcrypto/algorithm/common
+```
+
+## SHA3-256
+
+```nim
+let d = sha3_256("abc")
+let hex = sha3_256Hex("abc")
+let d2 = Sha3_256Digest.fromHexSha3_256(hex)
+```
+
+## Keccak-256
+
+```nim
+let k = keccak256("abc")
+let khex = keccak256Hex("abc")
+let k2 = Keccak256Digest.fromHexKeccak256(khex)
+```
+
+## secp256k1 ECDSA with SHA3 / Keccak
+
+The same module re-exports message-based ECDSA helpers that hash with SHA3-256 or Keccak-256 before signing:
+
+- `secp256k1EcdsaSignSha3_256` / `secp256k1EcdsaVerifySha3_256`
+- `secp256k1EcdsaSignKeccak256` / `secp256k1EcdsaVerifyKeccak256`
+
+See [secp256k1-ecdsa.md](./secp256k1-ecdsa.md).

--- a/docs/x509-certificates.md
+++ b/docs/x509-certificates.md
@@ -1,0 +1,32 @@
+# X.509 certificates (minimal)
+
+Module: `rustcrypto/algorithm/x509`
+
+Small helpers to validate certificates, convert between PEM and DER, and extract a few DER blobs (SubjectPublicKeyInfo, signature algorithm OID, subject, issuer).
+
+## Validate DER
+
+```nim
+import rustcrypto/algorithm/x509
+
+if x509CertValidateDer(certDer):
+  echo "DER parses as a supported certificate"
+```
+
+## PEM ↔ DER
+
+```nim
+let der = x509CertFromPem(pemString)
+let pem = x509CertToPem(der)
+```
+
+## Extract fields
+
+```nim
+let spki = x509CertSubjectPublicKeyInfoDer(der)
+let sigAlgOid = x509CertSignatureAlgorithmOid(der)
+let subject = x509CertSubjectDer(der)
+let issuer = x509CertIssuerDer(der)
+```
+
+This is **not** a full PKIX path validator: no chain building, revocation, or name constraints.

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,7 +1,8 @@
+#!/usr/bin/env bash
 cd /application/src/rustcrypto-ffi
 cargo build --release --lib
 
 cd /application/src/nim-rustcrypto
 nim r --hints:off --warnings:off src/rustcrypto/tools/sync_local_rustcrypto_ffi.nim
 nimble uninstall rustcrypto -iy || true
-nimble install -y
+nimble install -y 'https://github.com/itsumura-h/nim-rustcrypto?subdir=src/nim-rustcrypto'


### PR DESCRIPTION
- Updated README to provide a concise overview of the RustCrypto FFI, including features and installation instructions.
- Added detailed documentation for new cryptographic modules: AES-256-GCM, AES-256-GCM-SIV, ChaCha20-Poly1305, Argon2, and others.
- Introduced new documentation files for various algorithms, including usage examples and API details.
- Enhanced the `reinstall.sh` script to streamline the build and installation process for RustCrypto dependencies.
- Improved organization and clarity of existing documentation, ensuring comprehensive coverage of all cryptographic functionalities.