### PR TITLE
Add support for string-based JWK conversion and enhance JWT tests

### DIFF
--- a/src/nim-rustcrypto/src/rustcrypto/jwt.nim
+++ b/src/nim-rustcrypto/src/rustcrypto/jwt.nim
@@ -124,6 +124,9 @@ proc octJwkFromSecret(secret: openArray[byte]): Jwk =
   result.kty = "oct"
   result.k = base64UrlEncode(secret)
 
+proc octJwkFromSecret(secret: string): Jwk =
+  octJwkFromSecret(stringToBytes(secret))
+
 proc ecJwkFromSecret(secretKey: P256SecretKey): Jwk =
   let publicKey = P256.publicKeyUncompressed(secretKey)
   result.kty = "EC"
@@ -198,6 +201,9 @@ proc generateSecretKey*(T: type Jwt, algorithm: JwtAlgorithm): Jwk =
     okpJwkFromSecret(Ed25519.generateSecretKey())
   of jwtRS256, jwtPS256:
     raise newException(ValueError, "JWT RSA key generation is not supported yet")
+
+proc secretKey*(T: type Jwt, secret: string): Jwk =
+  octJwkFromSecret(secret)
 
 proc publicKey*(T: type Jwt, secretKey: Jwk): Jwk =
   case secretKey.kty

--- a/src/nim-rustcrypto/tests/test_jwt.nim
+++ b/src/nim-rustcrypto/tests/test_jwt.nim
@@ -1,6 +1,7 @@
 import std/base64
 import std/json
 import std/strutils
+import std/random
 import unittest
 
 import ./utils
@@ -12,7 +13,31 @@ proc toBase64Url(data: string): string =
   while result.len > 0 and result[^1] == '=':
     result.setLen(result.len - 1)
 
+proc randomString(maxLen: int): string =
+  let length = rand(maxLen)
+  result = newString(length)
+  for i in 0 ..< length:
+    result[i] = char(rand(255))
+
 suite "jwt":
+  test "random string secret can be converted to an oct JWK":
+    randomize(0)
+
+    let payload = %*{
+      "sub": 1234567890,
+      "name": "John Doe",
+      "admin": true
+    }
+    let secret = randomString(100)
+    let secretKey = Jwt.secretKey(secret)
+    let secretJwk = parseJson($secretKey)
+    let token = Jwt.sign(jwtHS256, payload, secretKey)
+
+    check secretJwk["kty"].getStr() == "oct"
+    check secretJwk["k"].getStr() == toBase64Url(secret)
+    check Jwt.verify(jwtHS256, Jwt.publicKey(secretKey), token)
+    check Jwt.decode(token) == payload
+
   test "marker type API round-trips with JWKs":
     let payload = %*{
       "sub": 1234567890,


### PR DESCRIPTION
- Introduced a new `octJwkFromSecret` procedure to convert string secrets into JWK format by leveraging existing byte array conversion.
- Added a `secretKey` procedure to facilitate the creation of JWKs from string secrets.
- Enhanced unit tests to validate the conversion of random string secrets to JWKs and ensure proper signing and verification of JWTs.
- Improved test coverage for JWT functionalities, confirming compliance with expected behaviors.